### PR TITLE
INFRA-415 Remove Version Constraints from Budget Alarm Module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,0 @@
-terraform {
-  required_version = "~> 0.12.6"
-
-  required_providers {
-    aws = "~> 2.37"
-  }
-}


### PR DESCRIPTION
This is not needed as we set version constraints at the top level. This actively breaks our Terraform and should be removed.