### PR TITLE
Removing the versions file and fixing variable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,13 @@ Report issues/questions/feature requests on in the [issues](https://github.com/r
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | ~> 0.12.6 |
-| aws | ~> 2.37 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.37 |
+| aws | n/a |
 | local | n/a |
 
 ## Inputs
@@ -116,7 +113,7 @@ Report issues/questions/feature requests on in the [issues](https://github.com/r
 | account\_name | Specifies the name of the AWS account | `string` | `""` | no |
 | budget\_limit\_unit | The unit of measurement used for the budget forecast, actual spend, or budget threshold. | `string` | `"USD"` | no |
 | budget\_time\_unit | The length of time until a budget resets the actual and forecasted spend. Valid values: `MONTHLY`, `QUARTERLY`, `ANNUALLY`. | `string` | `"MONTHLY"` | no |
-| create\_slack\_integration | Whether to create the Slack integration through AWS Chatbot or not. | `string` | `true` | no |
+| create\_slack\_integration | Whether to create the Slack integration through AWS Chatbot or not. | `bool` | `true` | no |
 | notifications | Can be used multiple times to configure budget notification thresholds | <pre>map(object({<br>    comparison_operator = string<br>    threshold           = number<br>    threshold_type      = string<br>    notification_type   = string<br>  }))</pre> | n/a | yes |
 | services | Define the list of services and their limit of budget | <pre>map(object({<br>    budget_limit = string<br>  }))</pre> | n/a | yes |
 | slack\_channel\_id | The ID of the Slack channel. To get the ID, open Slack, right click on the channel name in the left pane, then choose Copy Link. The channel ID is the 9-character string at the end of the URL. For example, ABCBBLZZZ. | `string` | n/a | yes |

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.66"
+  version = "= 3.25.0"
   region  = "eu-central-1"
 }
 
@@ -12,15 +12,6 @@ module "budget_alerts" {
   services = {
     Route53 = {
       budget_limit = 0.25
-    },
-    EC2 = {
-      budget_limit = 50.25
-    },
-    S3 = {
-      budget_limit = 12.35
-    },
-    ECR = {
-      budget_limit = 10.4
     }
   }
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -12,6 +12,15 @@ module "budget_alerts" {
   services = {
     Route53 = {
       budget_limit = 0.25
+    },
+    EC2 = {
+      budget_limit = 50.25
+    },
+    S3 = {
+      budget_limit = 12.35
+    },
+    ECR = {
+      budget_limit = 10.4
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "slack_workspace_id" {
 }
 
 variable "create_slack_integration" {
-  type        = string
+  type        = bool
   description = "Whether to create the Slack integration through AWS Chatbot or not."
   default     = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,0 @@
-terraform {
-  required_version = "~> 0.12.6"
-
-  required_providers {
-    aws = "~> 2.37"
-  }
-}


### PR DESCRIPTION
## Description

The `create_slack_integration` variable has a wrong format so that Terraform is not creating the resources related to ChatBot, fixing the variable to `bool`.

### Checklist

- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/rribeiro1/
terraform-aws-budget-alarms/#doc-generation
