### PR TITLE
Use the correct filter name for AWS MSK

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Make sure to set `create_slack_integration = false` to disable the integration.
 | ELB                         | Amazon Elastic Load Balancing.                     |
 | Gateway                     | Amazon API Gateway.                                |
 | Glue                        | AWS Glue.                                          |
-| Kafka                       | Managed Streaming for Apache Kafka.                |
+| Kafka                       | Amazon Managed Streaming for Apache Kafka.         |
 | KMS                         | AWS Key Management Service.                        |
 | Kinesis                     | Amazon Kinesis.                                    |
 | Lambda                      | AWS Lambda.                                        |

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
     ELB            = "Amazon Elastic Load Balancing"
     Gateway        = "Amazon API Gateway"
     Glue           = "AWS Glue"
-    Kafka          = "Managed Streaming for Apache Kafka"
+    Kafka          = "Amazon Managed Streaming for Apache Kafka"
     KMS            = "AWS Key Management Service"
     Kinesis        = "Amazon Kinesis"
     Lambda         = "AWS Lambda"


### PR DESCRIPTION
## Description

Use correct name for AWS MSK. Should be Amazon Managed Streaming for Apache Kafka.

### Checklist

- [x] CI tests are passing
- [x] README.md has been updated after any changes to variables and outputs. See https://github.com/rribeiro1/
terraform-aws-budget-alarms/#doc-generation
